### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ let's try a few configuration options:
 
 ### network
 
-- `networking.hostname = "star-darab";`
+- `networking.hostName = "star-darab";`
 - `networking.firewall.allowedTCPPorts = [ 22 80 8000 ];`
 
 


### PR DESCRIPTION
`networking.hostname -> networking.hostName`